### PR TITLE
Fix compilation with included libevent2...?

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,8 +40,6 @@ AM_CONDITIONAL(TR_UNSTABLE, test "x$supported_build" = "xno")
 ##
 CURL_MINIMUM=7.15.4
 AC_SUBST(CURL_MINIMUM)
-LIBEVENT_MINIMUM=2.0.10
-AC_SUBST(LIBEVENT_MINIUM)
 OPENSSL_MINIMUM=0.9.4
 AC_SUBST(OPENSSL_MINIMUM)
 
@@ -122,7 +120,6 @@ AC_SEARCH_LIBS([socket], [socket net])
 AC_SEARCH_LIBS([gethostbyname], [nsl bind])
 PKG_CHECK_MODULES(OPENSSL, [openssl >= $OPENSSL_MINIMUM], , [CHECK_SSL()])
 PKG_CHECK_MODULES(LIBCURL, [libcurl >= $CURL_MINIMUM])
-PKG_CHECK_MODULES(LIBEVENT, [libevent >= $LIBEVENT_MINIMUM])
 AC_PATH_ZLIB
 
 AC_SYS_LARGEFILE
@@ -202,6 +199,16 @@ AC_CHECK_LIB([rt],
              [clock_gettime],
              [libevent_extra_libs="-lrt"],
              [libevent_extra_libs=""])
+
+
+dnl ----------------------------------------------------------------------------
+dnl
+dnl  libevent
+
+LIBEVENT_CFLAGS="-I\$(top_srcdir)/third-party/libevent/include"
+LIBEVENT_LIBS="\$(top_builddir)/third-party/libevent/.libs/libevent.a"
+AC_SUBST(LIBEVENT_CFLAGS)
+AC_SUBST(LIBEVENT_LIBS)
 
 
 dnl ----------------------------------------------------------------------------
@@ -474,6 +481,7 @@ AC_CONFIG_FILES([Makefile
                  web/javascript/jquery/Makefile
                  web/stylesheets/Makefile
                  po/Makefile.in])
+AC_CONFIG_SUBDIRS([third-party/libevent])
 
 ac_configure_args="$ac_configure_args --enable-static --disable-shared -q"
 AC_OUTPUT

--- a/libtransmission/JSON_parser.c
+++ b/libtransmission/JSON_parser.c
@@ -69,7 +69,7 @@ SOFTWARE.
 #include <locale.h>
 
 #include <stdarg.h> /* some 1.4.x versions of evutil.h need this */
-#include <evutil.h> /* evutil_strtoll() */
+#include <event2/util.h> /* evutil_strtoll() */
 
 #include "JSON_parser.h"
 

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -45,7 +45,7 @@
 #include <unistd.h>
 
 #include <stdarg.h> /* some 1.4.x versions of evutil.h need this */
-#include <evutil.h>
+#include <event2/util.h>
 
 #include "transmission.h"
 #include "fdlimit.h"

--- a/libtransmission/peer-mgr.c
+++ b/libtransmission/peer-mgr.c
@@ -16,7 +16,9 @@
 #include <string.h> /* memcpy, memcmp, strstr */
 #include <stdlib.h> /* qsort */
 
-#include <event.h>
+#include <event2/event.h>
+#include <event2/event_compat.h>
+#include <event2/event_struct.h>
 
 #include "transmission.h"
 #include "announcer.h"

--- a/libtransmission/port-forwarding.c
+++ b/libtransmission/port-forwarding.c
@@ -16,7 +16,9 @@
 
 #include <sys/types.h>
 
-#include <event.h>
+#include <event2/event.h>
+#include <event2/event_struct.h>
+#include <event2/event_compat.h>
 
 #include "transmission.h"
 #include "natpmp.h"

--- a/libtransmission/rpc-server.c
+++ b/libtransmission/rpc-server.c
@@ -24,8 +24,11 @@
  #include <zlib.h>
 #endif
 
-#include <event.h>
-#include <evhttp.h>
+#include <event2/buffer.h>
+#include <event2/buffer_compat.h>
+#include <event2/event.h>
+#include <event2/http.h>
+#include <event2/http_struct.h>
 
 #include "transmission.h"
 #include "bencode.h"

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -21,7 +21,8 @@
  #include <zlib.h>
 #endif
 
-#include <event.h> /* evbuffer */
+#include <event2/event.h>
+#include <event2/buffer.h>
 
 #include "transmission.h"
 #include "bencode.h"

--- a/libtransmission/session.c
+++ b/libtransmission/session.c
@@ -21,7 +21,9 @@
 #include <unistd.h> /* stat */
 #include <dirent.h> /* opendir */
 
-#include <event.h>
+#include <event2/event.h>
+#include <event2/event_compat.h>
+#include <event2/event_struct.h>
 
 //#define TR_SHOW_DEPRECATED
 #include "transmission.h"

--- a/libtransmission/torrent.c
+++ b/libtransmission/torrent.c
@@ -24,7 +24,7 @@
 #include <stdlib.h> /* qsort */
 
 #include <stdarg.h> /* some 1.4.x versions of evutil.h need this */
-#include <evutil.h> /* evutil_vsnprintf() */
+#include <event2/util.h> /* evutil_vsnprintf() */
 
 #include "transmission.h"
 #include "announcer.h"

--- a/libtransmission/trevent.c
+++ b/libtransmission/trevent.c
@@ -18,7 +18,9 @@
 
 #include <signal.h>
 
-#include <event.h>
+#include <event2/event.h>
+#include <event2/event_compat.h>
+#include <event2/event_struct.h>
 
 #include "transmission.h"
 #include "net.h"

--- a/third-party/Makefile.am
+++ b/third-party/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = libnatpmp miniupnp dht
+SUBDIRS = libnatpmp miniupnp dht libevent
 
 EXTRA_DIST = \
   macosx-libevent-config.h \


### PR DESCRIPTION
I'm not sure if this is the best way to accomplish it, but here is one way to have transmission use the folded-in libevent2. Without these or similar changes it seems kind of pointless to included in the repository. Or maybe I misunderstood what you had in mind?

Also, libtransmission still includes the old libevent headers, so I made minimal changes to use the libevent2 ones. Perhaps this could be passed on the the transmission devs, if you think they might find it useful.
